### PR TITLE
Have tonk compare all of an author's roles to the channel/server mpaManagerRoles config list instead of the top role

### DIFF
--- a/tonk.py
+++ b/tonk.py
@@ -91,31 +91,31 @@ async def isManager(ctx):
         return True
     dbQuery = tonkDB.gidQueryDB(ctx.guild.id)
     mpaManagerRoles = parseDB.getMpaManagerRoles(ctx.channel.id, dbQuery)
-    mpaChannelList = dbQuery['Items'][0]['mpaChannels']
-    authorRoleID = str(ctx.author.top_role.id)
-    if type(mpaManagerRoles) is dict:
-        if mpaManagerRoles['channelManagerRoles'] is not None:
-            # Return true if the user's role is in either channel OR server manager roles, else return false
-            if authorRoleID in mpaManagerRoles['channelManagerRoles']:
+    # Compares author's roles to any configured role list, beginning with the channel specific settings
+    try:
+        # Return true if the user's role is in either channel OR server manager roles, else return false
+        authorID = [str(role.id) for role in ctx.author.roles]
+        sameRoles = (set(authorID)).intersection(set(mpaManagerRoles['channelManagerRoles']))
+        print (sameRoles)
+        if len(sameRoles) > 0:
+            return True
+        # User is not in channelManagerRoles and serverManagerRoles is not blank
+        elif (mpaManagerRoles['serverManagerRoles']) is not None:
+            sameRoles = (set(ctx.author.roles)).intersection(set(mpaManagerRoles['serverManagerRoles']))
+            if len(sameRoles) > 0:
                 return True
-            # User is not in channelManagerRoles and serverManagerRoles is not blank
-            elif (mpaManagerRoles['serverManagerRoles']) is not None:
-                if authorRoleID in mpaManagerRoles['serverManagerRoles']:
-                    return True
-            # These if statements should be ending the function on the return statement, if none of those conditions are met we return false.
-            return False
-        # Case: Channel manager roles is NOT configured, but server manager roles are
-        elif mpaManagerRoles['serverManagerRoles'] is not None:
-            if authorRoleID in mpaManagerRoles['serverManagerRoles']:
-                return True
-            else:
-                return False
-        # Other cases which is most likely both dictionaries are not configured at all.
-        elif (str(ctx.channel.id)) in (mpaChannelList):
-            return False
-        else:
-            return None
-    return None
+        return False
+    # Case: Channel manager roles is NOT configured, but server manager roles are
+    except TypeError:
+        print ('TypeError')
+        sameRoles = (set(ctx.author.roles)).intersection(set(mpaManagerRoles['serverManagerRoles']))
+        print(sameRoles)
+        if len(sameRoles) > 0:
+            return True
+        return False
+    except Exception:
+        traceback.print_exc(file=sys.stdout)
+        return None
 
 
 # Function called if the message ID in the expirationDate dictionary does not match with the new message ID passed by the mpaControl functions


### PR DESCRIPTION
From #2 

Tonk only checks an author's top role on the isManager() function to see if it is in any mpaManagerRoles config lists, and returns false if that top role is not present. 

The PR will enable Tonk to check all of the roles of the message author (the user who calls the command) and compare it to the config lists to see if any role ID the author has is in any of the lists

This PR will not change the top role administrator rule used for configs and the bypass. I may look into it in the future